### PR TITLE
Tracing the relevance of intermediate (hidden) layers

### DIFF
--- a/lrp/functional/conv.py
+++ b/lrp/functional/conv.py
@@ -3,6 +3,7 @@ import torch.nn.functional as F
 from torch.autograd import Function
 
 from .utils import identity_fn, gamma_fn, add_epsilon_fn, normalize
+from .. import trace
 
 def _forward_rho(rho, incr, ctx, input, weight, bias, stride, padding, dilation, groups):
         ctx.save_for_backward(input, weight, bias)
@@ -25,7 +26,9 @@ def _backward_rho(ctx, relevance_output):
     relevance_output = relevance_output / Z
     relevance_input  = F.conv_transpose2d(relevance_output, weight, None, padding=1)
     relevance_input  = relevance_input * input
-
+    # if we are tracing (i.e., keeping track of hidden layer relevance, put a copy of relevance_input in trace_stack)
+    if trace.trace_enabled:
+        trace.trace_stack.append(relevance_input.clone().detach())
     return relevance_input, None, None, None, None, None, None, 
 
 

--- a/lrp/functional/linear.py
+++ b/lrp/functional/linear.py
@@ -3,6 +3,7 @@ import torch.nn.functional as F
 from torch.autograd import Function
 
 from .utils import identity_fn, gamma_fn, add_epsilon_fn, normalize
+from .. import trace
 
 def _forward_rho(rho, incr, ctx, input, weight, bias):
     ctx.save_for_backward(input, weight, bias)
@@ -21,6 +22,9 @@ def _backward_rho(ctx, relevance_output):
     relevance_output = relevance_output / Z
     relevance_input  = F.linear(relevance_output, weight.t(), bias=None)
     relevance_input  = relevance_input * input
+    # if we are tracing (i.e., keeping track of hidden layer relevance, put a copy of relevance_input in trace_stack)
+    if trace.trace_enabled:
+        trace.trace_stack.append(relevance_input.clone().detach())
     return relevance_input, None, None
 
 class LinearEpsilon(Function):

--- a/lrp/trace.py
+++ b/lrp/trace.py
@@ -1,0 +1,13 @@
+trace_enabled=False
+trace_stack=None
+
+def enable_and_clean():
+    global trace_enabled,trace_stack
+    trace_stack=[]
+    trace_enabled=True
+
+def collect_and_disable():
+    global trace_enabled,trace_stack
+    old_stack=trace_stack
+    trace_stack=None
+    return old_stack


### PR DESCRIPTION
Added a simple ``trace`` module, with rudimentary ability to keep track of the relevance of intermediate (hidden) layers.

Use as follows

```python
lrp.trace.enable_and_clean()
y_hat.backward()
all_relevances=lrp.trace.collect_and_disable()

for i,t in enumerate(all_relevances):
    print(i,t.shape)
```

fixes my own issue #2 

